### PR TITLE
Fix certificate change dependency

### DIFF
--- a/terraform/cdn/cache-policy.tf
+++ b/terraform/cdn/cache-policy.tf
@@ -1,0 +1,18 @@
+resource "aws_cloudfront_cache_policy" "cache_all_qsa" {
+  name        = "Cache-All-QSA-${var.environment_name}"
+  comment     = "Cache all QSA (managed by terraform)"
+  default_ttl = 86400
+  max_ttl     = 31536000
+  min_ttl     = 1
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config {
+      cookie_behavior = "none"
+    }
+    headers_config {
+      header_behavior = "none"
+    }
+    query_strings_config {
+      query_string_behavior = "all"
+    }
+  }
+}

--- a/terraform/cdn/main.tf
+++ b/terraform/cdn/main.tf
@@ -51,7 +51,7 @@ module "cdn" {
 
       compress        = true
       cookies_forward = "all"
-      headers         = ["*"]
+      headers         = []
       query_string    = true
 
       allowed_methods = [
@@ -73,7 +73,11 @@ module "cdn" {
   }
   viewer_certificate = {
     ssl_support_method  = "sni-only"
-    acm_certificate_arn = module.acm.certificate_arn
+    acm_certificate_arn = module.acm.aws_acm_certificate_arn
+
+    depends_on = [
+      module.acm.aws_acm_certificate_arn
+    ]
   }
 }
 

--- a/terraform/cdn/main.tf
+++ b/terraform/cdn/main.tf
@@ -46,13 +46,11 @@ module "cdn" {
       target_origin_id       = "frontend-govpaas-${var.environment_name}"
       viewer_protocol_policy = "redirect-to-https"
 
+      cache_policy_id = aws_cloudfront_cache_policy.cache_all_qsa.id
+      origin_request_policy_id = aws_cloudfront_origin_request_policy.forward_all_qsa.id
+
       default_ttl = 0
       max_ttl     = 0
-
-      compress        = true
-      cookies_forward = "all"
-      headers         = []
-      query_string    = true
 
       allowed_methods = [
         "GET",

--- a/terraform/cdn/main.tf
+++ b/terraform/cdn/main.tf
@@ -52,6 +52,8 @@ module "cdn" {
       default_ttl = 0
       max_ttl     = 0
 
+      compress = true
+
       allowed_methods = [
         "GET",
         "HEAD",

--- a/terraform/cdn/origin-request-policy.tf
+++ b/terraform/cdn/origin-request-policy.tf
@@ -1,0 +1,13 @@
+resource "aws_cloudfront_origin_request_policy" "forward_all_qsa" {
+  name        = "Forward-All-QSA-${var.environment_name}"
+  comment     = "Forward all QSA (managed by terraform)"
+  cookies_config {
+    cookie_behavior = "all"
+  }
+  headers_config {
+    header_behavior = "allViewer"
+  }
+  query_strings_config {
+    query_string_behavior = "all"
+  }
+}

--- a/terraform/cdn/vars/development.tfvars
+++ b/terraform/cdn/vars/development.tfvars
@@ -1,4 +1,4 @@
 environment_name="development"
 environment_key="dev"
-cdn_aliases = ["dev.trade-tariff.service.gov.uk","assets-dev.trade-tariff.service.gov.uk" ]
+cdn_aliases = ["dev.trade-tariff.service.gov.uk", "assets-dev.trade-tariff.service.gov.uk"]
 origin_endpoint="tariff-frontend-dev.london.cloudapps.digital"

--- a/terraform/modules/cloudfront/main.tf
+++ b/terraform/modules/cloudfront/main.tf
@@ -92,16 +92,26 @@ resource "aws_cloudfront_distribution" "this" {
       default_ttl = lookup(i.value, "default_ttl", null)
       max_ttl     = lookup(i.value, "max_ttl", null)
 
+      cache_policy_id = i.value["cache_policy_id"]
+      origin_request_policy_id = i.value["origin_request_policy_id"]
+
+# TODO: Revisit after Terraform issue is fixed
+# This block should be ignored and removed from the plan  by terraform then cache_policy_id is used.
+# https://github.com/hashicorp/terraform-provider-aws/issues/17626
+
+
+      /*
       forwarded_values {
         query_string            = lookup(i.value, "query_string", false)
         query_string_cache_keys = lookup(i.value, "query_string_cache_keys", [])
-        headers                 = lookup(i.value, "headers", null)
+        headers                 = lookup(i.value, "headers", [])
 
         cookies {
           forward           = lookup(i.value, "cookies_forward", "none")
-          whitelisted_names = lookup(i.value, "cookies_whitelisted_names", null)
+          whitelisted_names = lookup(i.value, "cookies_whitelisted_names", [])
         }
       }
+      */
 
       dynamic "lambda_function_association" {
         for_each = lookup(i.value, "lambda_function_association", [])

--- a/terraform/modules/cloudfront/outputs.tf
+++ b/terraform/modules/cloudfront/outputs.tf
@@ -1,7 +1,7 @@
 output "aws_cloudfront_distribution_id" {
-  value = aws_cloudfront_distribution.this.id
+  value = aws_cloudfront_distribution.this[0].id
 }
 
 output "aws_cloudfront_distribution_arn" {
-  value = aws_cloudfront_distribution.this.arn
+  value = aws_cloudfront_distribution.this[0].arn
 }


### PR DESCRIPTION
Fixes:
- Wait for certificate creation and validation before swapping, on certificate change.
- Do not cache on all headers (results in no-caching) 