### PR TITLE
Removes asset host alias

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,6 @@
 *.tfstate
 *.tfstate.*
 
-*.lock.hcl
-
 # Crash log files
 crash.log
 
@@ -38,3 +36,4 @@ terraform.rc
 *.iml
 .idea/**
 
+.nvimlog

--- a/terraform/api-docs/.terraform.lock.hcl
+++ b/terraform/api-docs/.terraform.lock.hcl
@@ -1,0 +1,19 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "3.22.0"
+  hashes = [
+    "h1:8aWXjFcmEi64P0TMHOCQXWws+/SmvJQrNvHlzdktKOM=",
+    "zh:4a9a66caf1964cdd3b61fb3ebb0da417195a5529cb8e496f266b0778335d11c8",
+    "zh:514f2f006ae68db715d86781673faf9483292deab235c7402ff306e0e92ea11a",
+    "zh:5277b61109fddb9011728f6650ef01a639a0590aeffe34ed7de7ba10d0c31803",
+    "zh:67784dc8c8375ab37103eea1258c3334ee92be6de033c2b37e3a2a65d0005142",
+    "zh:76d4c8be2ca4a3294fb51fb58de1fe03361d3bc403820270cc8e71a04c5fa806",
+    "zh:8f90b1cfdcf6e8fb1a9d0382ecaa5056a3a84c94e313fbf9e92c89de271cdede",
+    "zh:d0ac346519d0df124df89be2d803eb53f373434890f6ee3fb37112802f9eac59",
+    "zh:d6256feedada82cbfb3b1dd6dd9ad02048f23120ab50e6146a541cb11a108cc1",
+    "zh:db2fe0d2e77c02e9a74e1ed694aa352295a50283f9a1cf896e5be252af14e9f4",
+    "zh:eda61e889b579bd90046939a5b40cf5dc9031fb5a819fc3e4667a78bd432bdb2",
+  ]
+}

--- a/terraform/cdn/.terraform.lock.hcl
+++ b/terraform/cdn/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "3.33.0"
+  hashes = [
+    "h1:UJcZV5+xJmHHDCsm+s8+xMonccZvVD0jdGwHAoi7nJg=",
+    "zh:0e89b10323a59de9dd6f286423cc172cb1733683d654c886493c3bd4e43e6290",
+    "zh:288df55f0f4fac1e920cfa61616ac42a4e4414bd7a637902db03d0c7101f14ca",
+    "zh:303c9136c5bf97e6c1deda6e27f0d0931fe0eaaab547bf219b996623fb0ad522",
+    "zh:457a5da9f323e2781942df534153d000ea81727798ee0771177009d84b04aad7",
+    "zh:857fa3e29cc25ace76556a5edfded41628a3380cebf457e627576a83084852f8",
+    "zh:85e1eb383372f834630fac7b02ec9ae1e33d24d61cf5a7d832583a16e6b5add4",
+    "zh:9dd01eb05ac73146ac5f25421b7683fe4bffec23e408162887e1265f9bfe8462",
+    "zh:b1561e1335754ec93a54f45c18dc1cab70f38bc08adf244d793791134f5641ef",
+    "zh:bb96f57b80e3d94ee4bc05a5450fdd796424272b46cfc67ff9d094d5316c5fac",
+    "zh:e4ce241d8b5dd1124dc0f1da6c0840ab777de8717dac6e76afbbad9883f5ce34",
+    "zh:f2b292e813844d6d611db89017fc420ac05f2e3b25324e3c893481d375e23396",
+  ]
+}

--- a/terraform/cdn/vars/development.tfvars
+++ b/terraform/cdn/vars/development.tfvars
@@ -1,4 +1,4 @@
 environment_name="development"
 environment_key="dev"
-cdn_aliases = ["dev.trade-tariff.service.gov.uk", "assets-dev.trade-tariff.service.gov.uk"]
+cdn_aliases = ["dev.trade-tariff.service.gov.uk"]
 origin_endpoint="tariff-frontend-dev.london.cloudapps.digital"

--- a/terraform/cdn/vars/production.tfvars
+++ b/terraform/cdn/vars/production.tfvars
@@ -1,4 +1,4 @@
 environment_name="production"
 environment_key="production"
-cdn_aliases = ["www.trade-tariff.service.gov.uk","assets.trade-tariff.service.gov.uk" ]
+cdn_aliases = ["www.trade-tariff.service.gov.uk"]
 origin_endpoint="tariff-frontend-production.london.cloudapps.digital"

--- a/terraform/cdn/vars/staging.tfvars
+++ b/terraform/cdn/vars/staging.tfvars
@@ -1,4 +1,4 @@
 environment_name="staging"
 environment_key="staging"
-cdn_aliases = ["staging.trade-tariff.service.gov.uk","assets-staging.trade-tariff.service.gov.uk" ]
+cdn_aliases = ["staging.trade-tariff.service.gov.uk"]
 origin_endpoint="tariff-frontend-staging.london.cloudapps.digital"


### PR DESCRIPTION
## What

Removes asset host alias to reflect the fact that we've removed the reference to it when rendering views in the application.

- [x] Removes from dev
- [x] Removes from staging
- [x] Removes from production

## Why

Because this is no longer used: https://github.com/trade-tariff/trade-tariff-frontend/pull/27
