### PR TITLE
Update name of search query parser ecr repo

### DIFF
--- a/terraform/common/variables.tf
+++ b/terraform/common/variables.tf
@@ -27,6 +27,6 @@ variable "docker_repositories" {
     "tariff-frontend",
     "tariff-dutycalculator",
     "tariff-admin",
-    "trade-tariff-search-query-parser",
+    "tariff-search-query-parser",
   ]
 }


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Renamed search query parser ecr repo

### Why?

I am doing this because:

- So we can be consistent with the other repo names
